### PR TITLE
Add custom data to RewardedAd

### DIFF
--- a/MTAdmob/Interfaces/IMTAdmob.shared.cs
+++ b/MTAdmob/Interfaces/IMTAdmob.shared.cs
@@ -16,8 +16,13 @@ namespace MarcTron.Plugin.Interfaces
         void LoadInterstitial(string adUnit);
         void ShowInterstitial();
 
-        bool IsRewardedVideoLoaded();        
+        bool IsRewardedVideoLoaded();
+
+#if !MONOANDROID81
+        public void LoadRewardedVideo(string adUnit, MTRewardedAdOptions options);
+#else
         void LoadRewardedVideo(string adUnit);
+#endif
         void ShowRewardedVideo();
 
 

--- a/MTAdmob/MTAdmob.android.cs
+++ b/MTAdmob/MTAdmob.android.cs
@@ -128,7 +128,11 @@ namespace MarcTron.Plugin
             return _rewardedAds != null && _rewardedAds.IsLoaded;
         }
 
+#if !MONOANDROID81
+        public void LoadRewardedVideo(string adUnit, MTRewardedAdOptions options = null)
+#else
         public void LoadRewardedVideo(string adUnit)
+#endif
         {
             if (_rewardedAds == null)
             {
@@ -147,6 +151,13 @@ namespace MarcTron.Plugin
                     }
                 }
 
+#if !MONOANDROID81
+                if (options != null)
+                {
+                    _rewardedAds.UserId = options.UserId;
+                    _rewardedAds.CustomData = options.CustomData;
+}
+#endif
                 _rewardedAds.LoadAd(adUnit, requestBuilder.Build());
             }
             else

--- a/MTAdmob/MTAdmob.apple.cs
+++ b/MTAdmob/MTAdmob.apple.cs
@@ -108,13 +108,15 @@ namespace MarcTron.Plugin
             return RewardBasedVideoAd.SharedInstance.IsReady;
         }
 
-        public void LoadRewardedVideo(string adUnit)
+        public void LoadRewardedVideo(string adUnit, MTRewardedAdOptions options = null)
         {
             if (RewardBasedVideoAd.SharedInstance.IsReady)
             {
                 OnRewardedVideoAdLoaded?.Invoke(null, null);
                 return;
             }
+
+            RewardBasedVideoAd.SharedInstance.CustomRewardString = options?.CustomData;
 
             var request = Request.GetDefaultRequest();
             RewardBasedVideoAd.SharedInstance.LoadRequest(request, adUnit);
@@ -137,7 +139,7 @@ namespace MarcTron.Plugin
 
         public override void DidRewardUser(RewardBasedVideoAd rewardBasedVideoAd, AdReward reward)
         {
-            OnRewarded?.Invoke(rewardBasedVideoAd, new MTEventArgs() {RewardAmount = (int) reward.Amount, RewardType = reward.Type});
+            OnRewarded?.Invoke(rewardBasedVideoAd, new MTEventArgs() { RewardAmount = (int)reward.Amount, RewardType = reward.Type });
         }
 
         public override void DidClose(RewardBasedVideoAd rewardBasedVideoAd)
@@ -152,7 +154,7 @@ namespace MarcTron.Plugin
 
         public override void DidFailToLoad(RewardBasedVideoAd rewardBasedVideoAd, NSError error)
         {
-            OnRewardedVideoAdFailedToLoad?.Invoke(rewardBasedVideoAd, new MTEventArgs() {ErrorCode = (int) error.Code});
+            OnRewardedVideoAdFailedToLoad?.Invoke(rewardBasedVideoAd, new MTEventArgs() { ErrorCode = (int)error.Code });
         }
 
         public override void DidOpen(RewardBasedVideoAd rewardBasedVideoAd)

--- a/MTAdmob/MTAdmob.csproj
+++ b/MTAdmob/MTAdmob.csproj
@@ -145,6 +145,10 @@
     <None Include="readme.txt" Pack="true" PackagePath="."></None>
   </ItemGroup>
 
+  <ItemGroup>
+    <None Remove="MTRewardedAdOptions.shared.cs" />
+  </ItemGroup>
+
   <!--Additional item groups-->
   <!--
   <ItemGroup Condition=" $(TargetFramework.StartsWith('Xamarin.TVOS')) ">

--- a/MTAdmob/MTAdmob.uwp.cs
+++ b/MTAdmob/MTAdmob.uwp.cs
@@ -42,7 +42,7 @@ namespace MarcTron.Plugin
         {
         }
 
-        public void LoadRewardedVideo(string adUnit)
+        public void LoadRewardedVideo(string adUnit, MTRewardedAdOptions options = null)
         {
         }
 

--- a/MTAdmob/MTRewardedAdOptions.shared.cs
+++ b/MTAdmob/MTRewardedAdOptions.shared.cs
@@ -1,0 +1,9 @@
+﻿namespace MarcTron.Plugin
+{
+    public class MTRewardedAdOptions
+    {
+        public string CustomData { get; set; }
+
+        public string UserId { get; set; }
+    }
+}


### PR DESCRIPTION
Add the ability to set custom data to RewardedAd for SSV.

See : [Android](https://developers.google.com/android/reference/com/google/android/gms/ads/reward/RewardedVideoAd#setCustomData(java.lang.String)), [iOS](https://developers.google.com/admob/ios/api/reference/Classes/GADRewardBasedVideoAd#/c:objc(cs)GADRewardBasedVideoAd(py)customRewardString)
