### PR TITLE
AdSize.SmartBanner is deprecated. It is replaced by GetCurrentOrientationAnchoredAdaptiveBannerAdSize.

### DIFF
--- a/MTAdmob/Controls/MTAdView.shared.cs
+++ b/MTAdmob/Controls/MTAdView.shared.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using MarcTron.Plugin.CustomEventArgs;
 using Xamarin.Forms;
 
 namespace MarcTron.Plugin.Controls
@@ -10,7 +11,7 @@ namespace MarcTron.Plugin.Controls
         public event EventHandler AdsClosed;
         public event EventHandler AdsImpression;
         public event EventHandler AdsOpened;
-        public event EventHandler AdsFailedToLoad;
+        public event EventHandler<MTEventArgs> AdsFailedToLoad;
         public event EventHandler AdsLeftApplication;
         public event EventHandler AdsLoaded;
 
@@ -57,7 +58,7 @@ namespace MarcTron.Plugin.Controls
             AdsOpened?.Invoke(sender, e);
         }
 
-        internal void AdFailedToLoad(object sender, EventArgs e)
+        internal void AdFailedToLoad(object sender, MTEventArgs e)
         {
             AdsFailedToLoad?.Invoke(sender, e);
         }

--- a/MTAdmob/Listeners/MyAdBannerListener.android.cs
+++ b/MTAdmob/Listeners/MyAdBannerListener.android.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Android.Gms.Ads;
+using MarcTron.Plugin.CustomEventArgs;
 
 namespace MarcTron.Plugin.Listeners
 {
@@ -9,7 +10,7 @@ namespace MarcTron.Plugin.Listeners
         public event EventHandler AdClosed;
         public event EventHandler AdImpression;
         public event EventHandler AdOpened;
-        public event EventHandler AdFailedToLoad;
+        public event EventHandler<MTEventArgs> AdFailedToLoad;
         public event EventHandler AdLeftApplication;
         public event EventHandler AdLoaded;
 
@@ -37,11 +38,32 @@ namespace MarcTron.Plugin.Listeners
             AdOpened?.Invoke(this, null);
         }
 
-        //public override void OnAdFailedToLoad(int errorCode)
-        //{
-        //    base.OnAdFailedToLoad(errorCode);
-        //    AdFailedToLoad?.Invoke(this, null);
-        //}
+        public override void OnAdFailedToLoad(LoadAdError adError)
+        {
+            base.OnAdFailedToLoad(adError);
+            
+            var errorMessage = "Unknown error";
+            
+            switch (adError.Code)
+            {
+                case AdRequest.ErrorCodeInternalError:
+                    errorMessage = "Internal error, an invalid response was received from the ad server.";
+                    break;
+                case AdRequest.ErrorCodeInvalidRequest:
+                    errorMessage = "Invalid ad request, possibly an incorrect ad unit ID was given.";
+                    break;
+                case AdRequest.ErrorCodeNetworkError:
+                    errorMessage = "The ad request was unsuccessful due to network connectivity.";
+                    break;
+                case AdRequest.ErrorCodeNoFill:
+                    errorMessage = "The ad request was successful, but no ad was returned due to lack of ad inventory.";
+                    break;
+            }
+           
+            AdFailedToLoad?.Invoke(this, new MTEventArgs 
+                { ErrorCode = adError.Code, ErrorMessage = errorMessage }
+            );
+        }
 
         //public override void OnAdLeftApplication()
         //{

--- a/MTAdmob/Renderers/AdViewRenderer.android.cs
+++ b/MTAdmob/Renderers/AdViewRenderer.android.cs
@@ -7,6 +7,9 @@ using MarcTron.Plugin.Listeners;
 using Xamarin.Forms;
 using Xamarin.Forms.Platform.Android;
 using MarcTron.Plugin.Renderers;
+using Android.Util;
+using Android.Runtime;
+using Android.Views;
 
 [assembly: ExportRenderer(typeof(MTAdView), typeof(AdViewRenderer))]
 
@@ -15,7 +18,6 @@ namespace MarcTron.Plugin.Renderers
     public class AdViewRenderer : ViewRenderer<MTAdView, AdView>
     {
         string _adUnitId = string.Empty;
-        readonly AdSize _adSize = AdSize.SmartBanner;
         AdView _adView;
 
         public AdViewRenderer(Context context) : base(context)
@@ -49,7 +51,7 @@ namespace MarcTron.Plugin.Renderers
 
             _adView = new AdView(Context)
             {
-                AdSize = _adSize,
+                AdSize = GetAdSize(),
                 AdUnitId = _adUnitId,
                 AdListener = listener,
                 LayoutParameters = new LinearLayout.LayoutParams(LayoutParams.WrapContent, LayoutParams.WrapContent)
@@ -70,6 +72,21 @@ namespace MarcTron.Plugin.Renderers
                 CreateNativeControl(e.NewElement, e.NewElement.AdsId);
                 SetNativeControl(_adView);
             }
+        }
+        
+        private AdSize GetAdSize()
+        {
+            var outMetrics = new DisplayMetrics();
+            var display = Context?.GetSystemService(Context.WindowService).JavaCast<IWindowManager>();
+
+            display?.DefaultDisplay?.GetMetrics(outMetrics);
+
+            float widthPixels = outMetrics.WidthPixels;
+            float density = outMetrics.Density;
+
+            int adWidth = (int)(widthPixels / density);
+
+            return AdSize.GetCurrentOrientationAnchoredAdaptiveBannerAdSize(Context, adWidth);
         }
     }
 }

--- a/Sample/SampleMTAdmob/MainPage.xaml
+++ b/Sample/SampleMTAdmob/MainPage.xaml
@@ -16,7 +16,17 @@
                    HorizontalOptions="Center"
                    VerticalOptions="CenterAndExpand" />
             <!-- Place the Admob controls here -->
-            <controls:MTAdView x:Name="myAds" IsVisible="true" AdsId="ca-app-pub-3940256099942544/6300978111" VerticalOptions="EndAndExpand" >
+            <controls:MTAdView 
+                x:Name="myAds"
+                AdsClicked="MyAds_AdsClicked"
+                AdsClosed="MyAds_AdVClosed"
+                AdsFailedToLoad="MyAds_AdFailedToLoad"
+                AdsId="ca-app-pub-3940256099942544/6300978111"
+                AdsImpression="MyAds_AdVImpression"
+                AdsLoaded="MyAds_AdLoaded"
+                AdsOpened="MyAds_AdVOpened"
+                IsVisible="true"
+                VerticalOptions="EndAndExpand">
                 <controls:MTAdView.HeightRequest>
                     <x:OnIdiom>
                         <x:OnIdiom.Phone>50</x:OnIdiom.Phone>

--- a/Sample/SampleMTAdmob/MainPage.xaml.cs
+++ b/Sample/SampleMTAdmob/MainPage.xaml.cs
@@ -29,7 +29,7 @@ namespace SampleMTAdmob
             //MTAdView myAds = new MTAdView();
             //myAds.AdsId = "xxx";
             //myAds.PersonalizedAds = true;
-            //myAds.AdsClicked += MyAdsAdsClicked;
+            //myAds.AdsClicked += MyAds_AdsClicked;
             //myAds.AdsClosed += MyAds_AdVClosed;
             //myAds.AdsImpression += MyAds_AdVImpression;
             //myAds.AdsOpened += MyAds_AdVOpened;
@@ -131,11 +131,20 @@ namespace SampleMTAdmob
             Console.WriteLine("MyAds_AdVClosed");
         }
 
-        private void MyAdsAdsClicked(object sender, EventArgs e)
+        private void MyAds_AdsClicked(object sender, EventArgs e)
         {
-            Console.WriteLine("MyAdsAdsClicked");
+            Console.WriteLine("MyAds_AdsClicked");
         }
 
+        private void MyAds_AdFailedToLoad(object sender, MTEventArgs e)
+        {
+            Debug.WriteLine($"MyAds_AdFailedToLoad: {e.ErrorCode} - {e.ErrorMessage}");
+        }
+
+        private void MyAds_AdLoaded(object sender, EventArgs e)
+        {
+            Console.WriteLine("MyAds_AdLoaded");
+        }
 
         private void LoadReward_OnClicked(object sender, EventArgs e)
         {

--- a/Sample/SampleMTAdmob/SecondPage.xaml.cs
+++ b/Sample/SampleMTAdmob/SecondPage.xaml.cs
@@ -117,7 +117,16 @@ public partial class SecondPage : ContentPage
         {
             Console.WriteLine("2MyAdsAdsClicked");
         }
+        
+        private void MyAds_AdFailedToLoad(object sender, MTEventArgs e)
+        {
+            Debug.WriteLine($"2MyAds_AdFailedToLoad: {e.ErrorCode} - {e.ErrorMessage}");
+        }
 
+        private void MyAds_AdLoaded(object sender, EventArgs e)
+        {
+            Console.WriteLine("2MyAds_AdLoaded");
+        }
 
         private void LoadReward_OnClicked(object sender, EventArgs e)
         {


### PR DESCRIPTION
`AdSize.SmartBanner` is [deprecated](https://developers.google.com/android/reference/com/google/android/gms/ads/AdSize#field-summary). Replacement by `GetCurrentOrientationAnchoredAdaptiveBannerAdSize` to return an AdSize with the given width and a height optimized by Google to create a banner ad, according to the [documentation](https://developers.google.com/android/reference/com/google/android/gms/ads/AdSize#public-static-adsize-getcurrentorientationanchoredadaptivebanneradsize-context-context,-int-width).